### PR TITLE
Add most basic cargo crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rustere"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn is_odd(x: usize) -> bool {
+    x % 2 == 1
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,28 @@
+use std::io;
+use rustere::is_odd;
+
+
+fn main() {
+    let guess_nb: usize;
+
+    loop {
+        println!("Enter a number to know if odd.");
+
+        let mut guess = String::new();
+
+        io::stdin()
+            .read_line(&mut guess)
+            .expect("Failed to read line");
+
+        guess_nb = match guess.trim().parse() {
+            Ok(num) => num,
+            Err(_) => continue,
+        };
+        break;
+    }
+
+    match is_odd(guess_nb) {
+        true => println!("{guess_nb} is odd."),
+        false => println!("{guess_nb} is even."),
+    }
+}


### PR DESCRIPTION
This PR adds the most basic cargo crate, just to use as a template of a possible crate.

Note that it is both a library crate and a binary crate, so that the user of this template can choose what to do.

Also it's recommended by the [Rust Book](https://doc.rust-lang.org/book/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html) to always have an entry point (a binary crate), even with library crate, so people can use and try it out.